### PR TITLE
Changing pylint rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -314,7 +314,7 @@ max-returns=6
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=1
 
 
 [EXCEPTIONS]


### PR DESCRIPTION
Decreased the minimum number of public methods in a class to 1